### PR TITLE
Update repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script is a very configurable botting tool for the MMO game [Moomoo.io](http://moomoo.io).
 
-### WARNING: Please do not download any code that claims that it will "fix" or "add features" to this bot code. People have been including trojans and viruses in those unofficial programs. The ONLY official Moomoo bot code authors are Mega-Mewthree and Nebula-Devs. DO NOT download any other code related to Moomoo bots.
+### WARNING: Please do not download any code that claims that it will "fix" or "add features" to this bot code. People have been including trojans and viruses in those unofficial programs. The ONLY official Moomoo bot code authors are `Mega-Mewthree` and `Nebula-Developers`. DO NOT download any other code related to Moomoo bots.
 
 We are not responsible for any damages caused by this project, or derivatives of this project. Use at your own risk.
 
@@ -11,7 +11,7 @@ We are not responsible for any damages caused by this project, or derivatives of
 * [Discord](https://discord.gg/VgKFcVf)
 * [Subreddit](https://reddit.com/r/Nebula_Devs)
 
-For contributors: [To-Do List](https://github.com/Mega-Mewthree/Moomoo-AI-Bot-Sender/projects/1)
+For contributors: [To-Do List](https://github.com/Nebula-Developers/Moomoo-AI-Bot-Sender/projects/1)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Mega-Mewthree",
+  "author": "Mega-Mewthree (Nebula-Developers)",
   "license": "GPL-3.0",
   "dependencies": {
     "auto-updater": "^1.0.2",
@@ -19,14 +19,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Mega-Mewthree/Moomoo-AI-Bot-Sender.git"
+    "url": "https://github.com/Nebula-Developers/Moomoo-AI-Bot-Sender.git"
   },
-  "bugs": "https://github.com/Mega-Mewthree/Moomoo-AI-Bot-Sender/issues",
+  "bugs": "https://github.com/Nebula-Developers/Moomoo-AI-Bot-Sender/issues",
   "engines": {
     "node": ">=7.6.0"
   },
   "auto-updater": {
-    "repo": "Mega-Mewthree/Moomoo-AI-Bot-Sender",
+    "repo": "Nebula-Developers/Moomoo-AI-Bot-Sender",
     "branch": "master"
   },
   "devDependencies": {


### PR DESCRIPTION
Since the repository was transferred from @Mega-Mewthree's account to the @Nebula-Developers organization, the URLs needed updating. Although redirects are automatically set up for transferred repositories at their old URL, this pull request updates the repositories in `package.json` and links in `README.md` in case the redirects disappear.